### PR TITLE
Fix: Ensure tailwind.config.mjs and use minimal globals.css

### DIFF
--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -1,16 +1,11 @@
-/* src/app/styles/globals.css */
-@tailwind base;
+/* src/app/styles/globals.css - More Minimal Experiment */
 
-/* Custom base styles and theme variables */
+/* Custom component styles that use @apply */
+@import "./components.css"; 
+
+/* Other custom styles */
 @import "./theme.css";
 @import "./base.css";
-
-@tailwind components;
-
-/* Custom component classes using @apply */
-@import "./components.css"; 
-@import "./animations.css"; /* If it contains component-like classes */
-@import "react-datepicker/dist/react-datepicker.css"; /* Datepicker styles */
-@import "./datepicker.css"; /* Custom overrides for datepicker */
-
-@tailwind utilities;
+@import "./animations.css";
+@import "react-datepicker/dist/react-datepicker.css";
+@import "./datepicker.css";

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,17 @@
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: [
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/styles/**/*.css", // Ensure CSS files are scanned for @apply
+  ],
+  theme: {
+    extend: {
+      // Future theme extensions can be added here.
+    },
+  },
+  plugins: [
+    // Future plugins can be added here.
+  ],
+};
+export default config;


### PR DESCRIPTION
This commit includes:
1.  A `tailwind.config.mjs` file with a comprehensive `content` array, including `"./src/app/styles/**/*.css"` to ensure Tailwind CSS scans local CSS files for `@apply` usage.
2.  A `globals.css` file that only imports custom stylesheets, omitting explicit `@tailwind` directives. This is an attempt to align with newer Next.js/Tailwind setups where these directives might be implicitly handled.

This configuration aims to resolve persistent "Cannot apply unknown utility class" errors by ensuring Tailwind correctly scans all relevant files and by simplifying the global CSS structure.