### PR TITLE
Fix header comment in WhychooseUsSection1

### DIFF
--- a/src/components/WhychooseUsSection1.jsx
+++ b/src/components/WhychooseUsSection1.jsx
@@ -1,4 +1,4 @@
-// src/components/WhyChooseUsModern.jsx
+// src/components/WhychooseUsSection1.jsx
 "use client";
 
 import React, { useRef } from "react";


### PR DESCRIPTION
## Summary
- fix the comment at the top of `WhychooseUsSection1.jsx`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f566c5d4083209b09209791825e43