### PR TITLE
Add booking API and store bookings in Firestore

### DIFF
--- a/src/app/api/bookings/route.js
+++ b/src/app/api/bookings/route.js
@@ -1,0 +1,19 @@
+import { db } from "@/lib/firebase";
+import { collection, addDoc, serverTimestamp } from "firebase/firestore";
+
+export async function POST(request) {
+  try {
+    const data = await request.json();
+    await addDoc(collection(db, "bookings"), {
+      ...data,
+      createdAt: serverTimestamp(),
+    });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  } catch (err) {
+    console.error("Fejl i /api/bookings:", err);
+    return new Response(
+      JSON.stringify({ error: "Kunne ikke gemme booking" }),
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/BookingModal.jsx
+++ b/src/components/BookingModal.jsx
@@ -97,6 +97,15 @@ export default function BookingModal({ onBooking }) {
       type: "booking",
     };
 
+    // Gem booking med API
+    fetch("/api/bookings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(bookingData),
+    }).catch((err) => {
+      console.error("Fejl ved gem af booking:", err);
+    });
+
     // Send data til parent
     onBooking(bookingData);
 


### PR DESCRIPTION
## Summary
- implement a `/api/bookings` endpoint for saving bookings
- call the API in `BookingModal` when a booking is confirmed

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841b080728083208c4849aa27f8553d